### PR TITLE
Add missing input formats from OpenCV (e.g. webp)

### DIFF
--- a/upscale.py
+++ b/upscale.py
@@ -156,7 +156,9 @@ class Upscale:
         )
 
         images: List[Path] = []
-        for ext in ["png", "jpg", "jpeg", "gif", "bmp", "tiff", "tga"]:
+        # List of extensions: https://docs.opencv.org/4.x/d4/da8/group__imgcodecs.html#ga288b8b3da0892bd651fce07b3bbd3a56
+        # Also gif and tga which seem to be supported as well though are undocumented.
+        for ext in ["bmp", "dib", "jpeg", "jpg", "jpe", "jp2", "png", "webp", "pbm", "pgm", "ppm", "pxm", "pnm", "pfm", "sr", "ras", "tiff", "tif", "exr", "hdr", "pic", "gif", "tga"]:
             images.extend(self.input.glob(f"**/*.{ext}"))
 
         # Store the maximum split depths for each model in the chain


### PR DESCRIPTION
I suspect that this PR may exacerbate performance issues caused by the use of a separate glob per input format. This is likely to be negligible compared to the time taken for inference for most users, but if desired, it should be possible to refactor the `for` loop so that it only uses a single glob operation.